### PR TITLE
docs: add comprehensive developer documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,11 +12,13 @@
 
 # Exclude from GitHub language stats
 /.github/** linguist-documentation
+/docs/** linguist-vendored
 
 # Exclude from GitHub-generated ZIP archives
 /tests                export-ignore
 /docker               export-ignore
 /bin                  export-ignore
+/docs                 export-ignore
 /.git*                export-ignore
 /.husky               export-ignore
 /package.json         export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,5 @@
 # Changelog
 
-## <small>1.0.2 (2025-08-11)</small>
-
-* chore: add keywords to composer.json ([4628a19](https://github.com/WPTechnix/wp-tables-schema/commit/4628a19))
-* chore: add missing description to composer.json ([23b5fed](https://github.com/WPTechnix/wp-tables-schema/commit/23b5fed))
-
-## 1.0.1 (2025-08-10)
-
-* chore: Updated composer.json description.
-
-## 1.0.0 (2025-08-10)
-
-* feat: added MetaTable and updated Table.php ([14d6b8e](https://github.com/WPTechnix/wp-tables-schema/commit/14d6b8e))
-* feat: added MetaTable and updated Table.php not to include id col by default ([d075087](https://github.com/WPTechnix/wp-tables-schema/commit/d075087))
-* feat: Introduce Table class for robust database table management (#2) ([bc8a95b](https://github.com/WPTechnix/wp-tables-schema/commit/bc8a95b)), closes [#2](https://github.com/WPTechnix/wp-tables-schema/issues/2)
-* feat(schema): add fluent MySQL CREATE TABLE builder with column, index, and foreign key support ([60772fe](https://github.com/WPTechnix/wp-tables-schema/commit/60772fe))
-* chore: initial commit ([f9dc215](https://github.com/WPTechnix/wp-tables-schema/commit/f9dc215))
-* chore: update README.md ([b9a609e](https://github.com/WPTechnix/wp-tables-schema/commit/b9a609e))
-* Initial commit ([a85d71c](https://github.com/WPTechnix/wp-tables-schema/commit/a85d71c))
-
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,144 @@
 # WP Tables Schema
 
-**WP Tables Schema** is a powerful, fluent, and modern PHP library for managing custom database tables within the WordPress environment. Inspired by the schema builder from frameworks like Laravel, it provides a robust, object-oriented API to handle table creation, schema migrations, and data manipulation, abstracting away the complexities of raw SQL and the limitations of `dbDelta`.
+A fluent, powerful, and developer-friendly library for creating and managing custom database tables in WordPress. Define your table schemas with an expressive API, handle versioning and migrations with ease, and build robust, modern data layers for your plugins.
 
-It offers a structured, version-controlled approach to database management, making your WordPress plugin or theme's data layer maintainable, readable, and safe.
+---
+
+## Key Features
+
+-   **Fluent Schema Builder**: Effortlessly define table columns, indexes, and relationships using a clean, chainable API.
+-   **Automated Migrations**: A simple, version-based migration system lets you evolve your database schema safely and predictably over time.
+-   **WordPress Integration**: Built to work seamlessly with the `$wpdb` object, prefixes, and the WordPress environment, including full multisite support.
+-   **Code-First Approach**: Define your entire database schema in version-controllable PHP, making it easy to track changes and collaborate.
+-   **Rich Type & Index Support**: Supports a wide range of MySQL/MariaDB column types, all index types (`UNIQUE`, `FULLTEXT`, `SPATIAL`), and foreign key constraints.
+-   **Powerful Helpers**: Includes an abstract `Meta_Table` class to instantly create WordPress-style metadata tables, plus schema macros for common patterns like timestamps and soft deletes.
+
+## Requirements
+
+-   PHP 8.0+
+-   WordPress 5.7+
+-   MySQL 5.6+ or MariaDB 10.1+
+
+## Installation
+
+The recommended way to install this library is through [Composer](https://getcomposer.org/):
+
+```bash
+composer require wptechnix/wp-tables-schema
+```
+
+## Quick Start Guide
+
+Let's create a custom database table for "Events" in 2 simple steps.
+
+### Step 1: Define Your Table Class
+
+Create a new PHP class that extends `Table`. This class is the single source of truth for your table's structure and version.
+
+**`src/Database/Tables/Events_Table.php`**
+```php
+<?php
+
+namespace Your_Plugin\Database\Tables;
+
+use WPTechnix\WP_Tables_Schema\Table;
+use WPTechnix\WP_Tables_Schema\Schema\Create_Table_Schema;
+
+class Events_Table extends Table
+{
+    /** The schema version. Increment this to run a new migration. */
+    protected int $schema_version = 10001;
+
+    /** The table name, without prefixes. */
+    protected string $table_name = 'events';
+    
+    /** A prefix for your plugin's tables to avoid conflicts. */
+    protected string $plugin_prefix = 'my_plugin_';
+    
+    // --- The rest of these properties are optional helpers ---
+    protected string $table_singular_name = 'event';
+    protected string $table_alias = 'e';
+    protected string $foreign_key_name = 'event_id';
+
+    /**
+     * The migration method to create the initial table structure.
+     * The method name `migrate_to_10001` matches the `$schema_version`.
+     */
+    protected function migrate_to_10001(): bool
+    {
+        return $this->create_table(
+            function (Create_Table_Schema $schema) {
+                // Creates an auto-incrementing `id` column as the primary key.
+                $schema->id();
+
+                // Creates a `title` column (VARCHAR) and adds an index to it.
+                $schema->string('title')->index();
+                
+                // Creates a `location` column that can be NULL.
+                $schema->string('location')->nullable();
+
+                // Creates a `starts_at` DATETIME column.
+                $schema->datetime('starts_at');
+                
+                // Creates `created_at` and `updated_at` columns automatically.
+                $schema->timestamps();
+
+                return $schema;
+            }
+        );
+    }
+}```
+
+### Step 2: Run the Installation
+
+In your main plugin file, hook a function to `register_activation_hook` to run the installer.
+
+**`my-plugin.php`**
+```php
+<?php
+
+use Your_Plugin\Database\Tables\Events_Table;
+
+/**
+ * The main installation function for the plugin.
+ */
+function my_plugin_install() {
+    global $wpdb;
+
+    // Create an instance of the table class and run the installation.
+    $events_table = new Events_Table($wpdb);
+    $events_table->install();
+}
+
+// Hook our installation function to run only when the plugin is activated.
+register_activation_hook(__FILE__, 'my_plugin_install');
+```
+
+That's it! When you activate your plugin, a `wp_my_plugin_events` table will be created with the exact structure you defined.
+
+---
+
+## Core Concepts
+
+-   **Schema Builder**: The fluent interface inside `create_table()` is where you define your table's columns (`string`, `integer`, etc.), modifiers (`nullable`, `default`), and indexes (`index`, `unique`).
+    -   [Learn more in the Schema Builder Guide](./docs/02-The-Schema-Builder.md)
+
+-   **Migrations**: To change a table, you simply increment `$schema_version` (e.g., to `10002`) and add a new `migrate_to_10002()` method. The library automatically detects and runs the new migration. You can add columns, drop indexes, and more.
+    -   [Learn how to evolve tables with the Migrations Guide](./docs/03-Evolving-Tables-with-Migrations.md)
+
+-   **Relationships**: You can easily create foreign key constraints to link tables, ensuring data integrity. The library provides clear, fluent methods for defining these critical relationships.
+    -   [Learn more in the Relationships Guide](./docs/04-Managing-Table-Relationships.md)
+
+-   **Helpers & Shortcuts**: The library is packed with helpers like the `Meta_Table` class for creating metadata tables in just a few lines of code, and schema macros like `timestamps()` and `soft_deletes()` to speed up development.
+    -   [Discover all the helpers in the Shortcuts Guide](./docs/05-Shortcuts-and-Helpers.md)
+
+## Full Documentation
+
+For a deep dive into every feature, please refer to the complete documentation:
+
+1.  [**Getting Started**](./docs/01-Getting-Started.md)
+2.  [**The Schema Builder**](./docs/02-The-Schema-Builder.md)
+3.  [**Evolving Tables with Migrations**](./docs/03-Evolving-Tables-with-Migrations.md)
+4.  [**Managing Table Relationships**](./docs/04-Managing-Table-Relationships.md)
+5.  [**Shortcuts and Helpers**](./docs/05-Shortcuts-and-Helpers.md)
+6.  [**Advanced Topics**](./docs/06-Advanced-Topics.md)

--- a/docs/01-Getting-Started.md
+++ b/docs/01-Getting-Started.md
@@ -1,0 +1,131 @@
+# 1. Getting Started
+
+Welcome to WP Tables Schema! This guide will walk you through the fundamental steps of setting up the library and creating your first custom database table.
+
+---
+
+### Installation
+
+First, ensure you have installed the library in your project using Composer:
+
+```bash
+composer require wptechnix/wp-tables-schema
+```
+
+Make sure your plugin includes the Composer autoloader:
+
+```php
+<?php
+// my-plugin.php
+
+require_once __DIR__ . '/vendor/autoload.php';
+```
+
+---
+
+### Core Concepts
+
+Before we build a table, let's understand the key ideas behind the library.
+
+#### The `Table` Class
+
+The foundation of the library is the abstract `Table` class. To create a custom database table, you will create a new PHP class that **extends** `Table`. This new class is the single source of truth for your table's structure and its migration history.
+
+#### Schema Versioning
+
+Every table class has a `$schema_version` property. This integer is crucial for managing database updates.
+
+-   When you first create a table, you'll set it to a starting version (e.g., `10001`).
+-   When you need to change the table later (e.g., add a new column), you will add a new migration method and **increment** this version number (e.g., to `10002`).
+
+The library uses this version to know which updates need to be run.
+
+#### The `install()` Method
+
+This is the main method you'll call. When `$my_table->install()` is executed, the library automatically:
+1.  Checks the current version of your table stored in the WordPress options table.
+2.  Compares it to the `$schema_version` defined in your PHP class.
+3.  Runs any necessary migration methods in order until the database schema is up to date.
+
+---
+
+### Step-by-Step: Creating Your First Table
+
+Let's create a simple table to store a list of "Tasks".
+
+#### Step 1: Define the Table Class
+
+First, create a new PHP file for your table definition. A good practice is to keep these in a dedicated directory, like `src/Database/Tables/`.
+
+**`src/Database/Tables/Tasks_Table.php`**
+```php
+<?php
+
+namespace Your_Plugin\Database\Tables;
+
+use WPTechnix\WP_Tables_Schema\Table;
+use WPTechnix\WP_Tables_Schema\Schema\Create_Table_Schema;
+
+class Tasks_Table extends Table
+{
+    protected int $schema_version = 10001;
+    protected string $table_name = 'tasks';
+    protected string $table_singular_name = 'task';
+    protected string $table_alias = 't';
+    protected string $foreign_key_name = 'task_id';
+    protected string $plugin_prefix = 'my_plugin_';
+
+    /**
+     * This method defines the initial table structure.
+     * The method name `migrate_to_10001` must match the `$schema_version`.
+     */
+    protected function migrate_to_10001(): bool
+    {
+        return $this->create_table(
+            function (Create_Table_Schema $schema) {
+                $schema->id(); // A standard primary key column named 'id'.
+                $schema->string('title')->index(); // A title column with an index.
+                $schema->string('priority', 20)->default('normal');
+                $schema->datetime('completed_at')->nullable();
+                $schema->timestamps(); // `created_at` and `updated_at` columns.
+                return $schema;
+            }
+        );
+    }
+}
+```
+
+#### Step 2: Trigger the Installation
+
+Now, you need to tell WordPress when to run this installation. The best practice for creating tables is to use `register_activation_hook`, which runs only once when the user activates your plugin.
+
+**`my-plugin.php`**
+```php
+<?php
+
+use Your_Plugin\Database\Tables\Tasks_Table;
+
+/**
+ * The main installation function for the plugin.
+ */
+function my_plugin_install() {
+    global $wpdb;
+
+    // Create an instance of our table class.
+    $tasks_table = new Tasks_Table($wpdb);
+
+    // Call the install() method to create the table.
+    $tasks_table->install();
+}
+
+// Hook our installation function to the plugin's activation.
+register_activation_hook(__FILE__, 'my_plugin_install');
+```
+
+And you're done! When a user activates your plugin, the library will automatically create the `wp_my_plugin_tasks` table with the exact schema you defined.
+
+### What's Next?
+
+You've successfully created a table. Now it's time to learn about all the powerful tools available in the schema builder to define your columns and indexes with precision.
+
+-   [**Next: The Schema Builder &rarr;**](./02-The-Schema-Builder.md)

--- a/docs/02-The-Schema-Builder.md
+++ b/docs/02-The-Schema-Builder.md
@@ -1,0 +1,159 @@
+# 2. The Schema Builder
+
+Now that you know how to create a basic table, let's explore the heart of this library: the fluent `Create_Table_Schema` builder. This tool gives you an expressive, easy-to-read API for defining every column, index, and option for your table right within your PHP code.
+
+You access the schema builder inside the `create_table()` method in your migration:
+
+```php
+protected function migrate_to_10001(): bool
+{
+    return $this->create_table(function (Create_Table_Schema $schema) {
+        // You'll define your entire table structure here using the $schema object.
+        return $schema;
+    });
+}
+```
+
+---
+
+### Defining Columns
+
+The schema builder offers a wide variety of methods that correspond to different SQL data types.
+
+#### Numeric Types
+
+| Method | SQL Type | Description |
+| :--- | :--- | :--- |
+| `->big_integer($name)` | `BIGINT` | For very large whole numbers. |
+| `->integer($name)` | `INT` | A standard 4-byte integer. |
+| `->medium_integer($name)` | `MEDIUMINT` | A 3-byte integer. |
+| `->small_integer($name)` | `SMALLINT` | A 2-byte integer. |
+| `->tiny_integer($name)` | `TINYINT` | A 1-byte integer, great for flags. |
+| `->boolean($name)` | `TINYINT(1)` | A specialized tiny integer for true/false values. |
+| `->decimal($name, $p, $s)`| `DECIMAL(p, s)` | For precise numbers with a fixed decimal point, ideal for currency. |
+| `->float($name)` | `FLOAT` | For single-precision floating-point numbers. |
+| `->double($name)` | `DOUBLE` | For double-precision floating-point numbers. |
+
+**Example:**
+```php
+$schema->integer('order_count');
+$schema->decimal('price', 10, 2); // Can store a value like 12345678.99
+```
+
+#### String & Text Types
+
+| Method | SQL Type | Description |
+| :--- | :--- | :--- |
+| `->string($name, $len = 191)` | `VARCHAR(len)` | For variable-length strings. The default length is ideal for indexed columns. |
+| `->char($name, $len = 1)` | `CHAR(len)` | For fixed-length strings, like country codes. |
+| `->text($name)` | `TEXT` | For short-form text content (up to ~64KB). |
+| `->medium_text($name)` | `MEDIUMTEXT` | For longer articles or content (up to ~16MB). |
+| `->long_text($name)` | `LONGTEXT` | For very large text content (up to ~4GB). |
+
+**Example:**
+```php
+$schema->string('customer_email', 100);
+$schema->long_text('product_description');
+```
+
+#### Date & Time Types
+
+| Method | SQL Type | Description |
+| :--- | :--- | :--- |
+| `->datetime($name)` | `DATETIME` | For storing a specific date and time. |
+| `->date($name)` | `DATE` | For storing dates only (no time). |
+| `->time($name)` | `TIME` | For storing times only (no date). |
+| `->timestamp($name)` | `TIMESTAMP` | Similar to `DATETIME` but often used for tracking record changes. |
+| `->year($name)` | `YEAR` | For storing a 4-digit year. |
+
+**Example:**
+```php
+$schema->date('start_date');
+$schema->datetime('appointment_time');
+```
+
+---
+
+### Applying Column Modifiers
+
+After choosing a column's type, you can chain **modifier methods** to add attributes and constraints. Think of these as adjectives that describe the column.
+
+-   `->nullable()`: Allows the column to store `NULL` values. By default, columns are `NOT NULL`.
+    ```php
+    $schema->string('middle_name')->nullable();
+    ```
+
+-   `->default($value)`: Sets a default value that the database will use if one isn't provided.
+    ```php
+    $schema->integer('vote_count')->default(0);
+    $schema->string('status')->default('pending');
+    ```
+
+-   `->unsigned()`: For numeric types, this prevents negative values and doubles the maximum positive value.
+    ```php
+    $schema->integer('user_id')->unsigned();
+    ```
+
+-   `->comment($text)`: Adds a descriptive comment to the column in the database schema, which is helpful for developers.
+    ```php
+    $schema->boolean('is_active')->comment('1 for active, 0 for inactive.');
+    ```
+
+---
+
+### Defining Keys and Indexes
+
+Indexes are crucial for fast database lookups. The schema builder makes adding them simple.
+
+#### Primary Keys
+
+Every table should have a primary key to uniquely identify each row. The library provides a convenient shortcut for the most common type of primary key.
+
+-   `->id($column_name = 'id')`: This powerful macro creates a `BIGINT UNSIGNED` column that is an `AUTO_INCREMENT PRIMARY KEY`.
+
+**Example:**
+```php
+$schema->id(); // Creates the 'id' column.
+$schema->id('task_id'); // Creates a primary key named 'task_id' with auto-increment.
+```
+
+#### Single-Column Indexes
+
+For simple indexes on a single column, you can chain a method directly onto the column definition.
+
+-   `->index()`: Adds a standard, non-unique index for fast searching.
+-   `->unique()`: Adds a unique index, ensuring no two rows have the same value in this column.
+
+**Example:**
+```php
+// An index makes searching for users by email much faster.
+$schema->string('email')->index();
+
+// A unique index prevents duplicate usernames.
+$schema->string('username')->unique();
+```
+
+#### Composite (Multi-Column) Indexes
+
+Sometimes you need an index that spans multiple columns. For this, you use dedicated schema methods.
+
+-   `->add_index(['column1', 'column2'], 'optional_index_name')`
+-   `->add_unique_key(['column1', 'column2'], 'optional_index_name')`
+
+**Scenario**: Imagine you are storing geographic data. You would often search for a `latitude` and `longitude` pair together. A composite index makes this much faster.
+
+```php
+$schema->decimal('latitude', 10, 7);
+$schema->decimal('longitude', 10, 7);
+
+// Add an index on both columns for efficient location lookups.
+$schema->add_index(['latitude', 'longitude']);
+```
+
+---
+
+### What's Next?
+
+You now have all the tools to design the perfect schema for a brand-new table. But what happens a year from now when you need to add a new column or index? The next guide will teach you how to safely modify your tables over time using migrations.
+
+-   [**Next: Evolving Tables with Migrations &rarr;**](./03-Evolving-Tables-with-Migrations.md)

--- a/docs/03-Evolving-Tables-with-Migrations.md
+++ b/docs/03-Evolving-Tables-with-Migrations.md
@@ -1,0 +1,143 @@
+# 3. Evolving Tables with Migrations
+
+Your plugin will grow, and your database will need to change with it. **Migrations** are a safe and organized way to alter your database tables *after* they have been created. Instead of writing raw `ALTER TABLE` SQL queries, you will use the library's clear and reliable helper methods.
+
+---
+
+### The Migration Golden Rule
+
+> **Never edit a migration method after it has been released.**
+
+Once your plugin is in the wild, you must assume that the migration has already run on a user's site. If you change it, that user will not get the new changes, leading to errors. To make a change, you must always create a **new** migration.
+
+### The Migration Workflow
+
+The process for changing an existing table is simple and methodical:
+
+1.  **Increment the Schema Version**: In your `Table` class, find the `$schema_version` property and increase its value by one. For example, if it's `10001`, change it to `10002`.
+2.  **Create a New Migration Method**: In the same class, add a new protected method. The method name **must** match the new version number: `protected function migrate_to_10002(): bool`.
+3.  **Implement the Changes**: Inside this new method, use the library's helper methods (`add_column`, `drop_index`, etc.) to make your desired changes.
+
+The library handles the rest. During your plugin's activation, it will see that the database is at an older version and automatically run your new migration method to bring it up to date.
+
+---
+
+### Modifying Columns
+
+The `Table` class provides several methods for altering columns. You call these from within your new migration method.
+
+#### Adding a Column
+
+This is the most common migration. Use `add_column()` to add a new column to the table.
+
+-   **`add_column(string $column_name, string $sql_definition, ?string $after_column = null)`**
+
+**Example**: Let's add a `status` column to our `Tasks` table.
+
+```php
+// In Tasks_Table.php...
+
+// 1. First, update the version number at the top of the class.
+protected int $schema_version = 10002;
+
+// 2. Then, add the new migration method.
+protected function migrate_to_10002(): bool
+{
+    // Adds a new VARCHAR(20) column named 'status', places it after the
+    // 'priority' column, and gives it a default value.
+    $this->add_column('status', "VARCHAR(20) NOT NULL DEFAULT 'pending'", 'priority');
+    
+    return true; // Return true to confirm the migration was successful.
+}
+```
+
+#### Dropping a Column
+
+To permanently remove a column and all its data, use `drop_column()`. **Warning:** This is a destructive action and cannot be undone.
+
+-   **`drop_column(string $column_name)`**
+
+**Example**:
+```php
+protected function migrate_to_10003(): bool
+{
+    $this->drop_column('some_old_column');
+    return true;
+}
+```
+
+#### Renaming a Column
+
+Use `rename_column()` if you only need to change a column's name without altering its type or attributes.
+
+-   **`rename_column(string $old_name, string $new_name)`**
+
+**Example**: Let's rename our `title` column to `task_name`.
+```php
+protected function migrate_to_10004(): bool
+{
+    $this->rename_column('title', 'task_name');
+    return true;
+}
+```
+
+#### Modifying a Column's Definition
+
+Use `modify_column()` when you need to change a column's data type, length, or other attributes.
+
+-   **`modify_column(string $column_name, string $new_sql_definition)`**
+
+**Example**: Let's change our `status` column to allow longer values.
+```php
+protected function migrate_to_10005(): bool
+{
+    // You must provide the *entire* new definition for the column.
+    $this->modify_column('status', "VARCHAR(30) NOT NULL DEFAULT 'pending'");
+    return true;
+}
+```
+
+---
+
+### Modifying Indexes and Keys
+
+You can also add or remove indexes in a migration.
+
+#### Adding an Index
+
+Use `add_index()` or `add_unique_key()` to add a new index to an existing column.
+
+-   **`add_index(string|array $columns, string $type = 'INDEX', ?string $name = null)`**
+
+**Example**: After adding our `status` column, let's add an index to it for faster queries.
+```php
+protected function migrate_to_10006(): bool
+{
+    // Adds a standard index to the 'status' column.
+    $this->add_index('status');
+    return true;
+}
+```
+
+#### Dropping an Index
+
+To remove an index, you need its name. If you didn't specify a name when you created it, the library generated one based on a predictable pattern (e.g., `idx_{table_name}_{column_name}`).
+
+-   **`drop_index(string $index_name)`**
+
+**Example**:
+```php
+protected function migrate_to_10007(): bool
+{
+    // The library would have named the index on the `status` column `idx_tasks_status`.
+    $this->drop_index('idx_tasks_status');
+    return true;
+}```
+
+---
+
+### What's Next?
+
+You are now fully equipped to create tables and safely evolve their structure over time. However, tables rarely exist in isolation. The next crucial concept is learning how to formally connect them using foreign keys to ensure your data remains consistent and reliable.
+
+-   [**Next: Managing Table Relationships &rarr;**](./04-Managing-Table-Relationships.md)

--- a/docs/04-Managing-Table-Relationships.md
+++ b/docs/04-Managing-Table-Relationships.md
@@ -1,0 +1,166 @@
+# 4. Managing Table Relationships
+
+Your tables rarely live in isolation. A well-designed database relies on clearly defined **relationships** to connect data and maintain its integrity. This is achieved using **foreign keys**.
+
+A foreign key is a rule you create that links a column in one table to a primary key in another. This guide will teach you how to master these relationships using the library's powerful tools.
+
+### Why Are Foreign Keys So Important?
+
+Imagine you have a `books` table and an `authors` table. A foreign key can enforce these critical rules:
+1.  You cannot add a book with an `author_id` that doesn't exist in the `authors` table.
+2.  You can control what happens to an author's books if that author is ever deleted from the database.
+
+This prevents "orphaned" records and ensures your data remains consistent and reliable.
+
+---
+
+## Part 1: Defining Relationships on Table Creation
+
+The most common time to create a relationship is when you are defining a "child" table that depends on a "parent" table.
+
+Let's continue our example with `Authors_Table` and `Books_Table`. Every book must have an author.
+
+**`src/Database/Tables/Books_Table.php`**
+```php
+protected function migrate_to_10001(): bool
+{
+    global $wpdb;
+
+    return $this->create_table(function (Create_Table_Schema $schema) use ($wpdb) {
+        $schema->id(); // Primary key for the books table.
+        $schema->string('title')->index();
+
+        // Step 1: Define the column that will store the link to the authors table.
+        // It must be an unsigned integer to match the parent's `id` column.
+        $schema->big_integer('author_id')->unsigned();
+
+        // Step 2: Add the foreign key constraint using a fluent chain.
+        $schema->add_foreign_key('author_id')
+               ->references(
+                   $wpdb->prefix . 'my_plugin_authors', // The FULL name of the parent table
+                   'id'                                 // The primary key of the parent table
+               )
+               ->on_delete('CASCADE'); // Defines what happens when an author is deleted.
+
+        return $schema;
+    });
+}
+```
+
+#### Breaking Down the `add_foreign_key` Chain
+
+-   `->add_foreign_key('author_id')`: You start by specifying the column in the current (`books`) table that will hold the reference.
+-   `->references('table_name', 'column_name')`: Next, you specify the parent table and column it is linking to. **Crucially, you must use the full, prefixed table name here.**
+-   `->on_delete('ACTION')`: This is the **referential action**. It's a rule that tells the database what to do if the parent row (the author) is deleted.
+
+#### Understanding Referential Actions
+
+This is the most powerful part of a foreign key. You can control the outcome when a parent row is deleted or updated.
+
+| Action | `on_delete()` Description |
+| :--- | :--- |
+| `CASCADE` | **(Common)** If the parent row is deleted, automatically delete all child rows that reference it. (e.g., deleting an author automatically deletes all their books). |
+| `SET NULL`| **(Common)** If the parent row is deleted, set the foreign key column in the child rows to `NULL`. The local column must be defined as `->nullable()` for this to work. |
+| `RESTRICT`| **(Default & Safest)** Prevents the parent row from being deleted if any child rows are still referencing it. An error will be thrown. |
+| `NO ACTION`| Similar to `RESTRICT` in most database systems. |
+
+You can also specify an `->on_update('ACTION')` rule, which defines what happens if the parent row's primary key value changes (a very rare event).
+
+---
+
+## Part 2: Managing Relationships in Migrations
+
+You can also add or drop foreign key relationships on tables that already exist.
+
+### `add_foreign_key()`
+
+Adds a foreign key constraint to an existing table. The column must already exist.
+
+#### Signature
+`add_foreign_key(string $column, string $ref_table, string $ref_column, ?string $constraint_name = null, string $on_delete = 'RESTRICT', string $on_update = 'RESTRICT'): bool`
+
+#### Example
+Let's add our author relationship to a `Books_Table` that was created without one.
+```php
+// In Books_Table.php...
+protected function migrate_to_10002(): bool
+{
+    global $wpdb;
+
+    // First, we need to ensure the `author_id` column exists.
+    $this->add_column('author_id', 'BIGINT UNSIGNED NULL', 'title');
+
+    // Now, we can add the foreign key constraint to it.
+    $this->add_foreign_key(
+        'author_id',                               // Local column
+        $wpdb->prefix . 'my_plugin_authors',       // Foreign table
+        'id',                                      // Foreign column
+        null,                                      // Let the library name the constraint
+        'SET NULL'                                 // ON DELETE action
+    );
+    
+    return true;
+}
+```
+
+### `drop_foreign_key()`
+
+Removes a foreign key constraint from a table. To do this, you need the unique name of the constraint.
+
+#### Signature
+`drop_foreign_key(string $constraint_name): bool`
+
+#### Finding the Constraint Name
+If you didn't provide a custom name when creating the key, the library generates one for you using the pattern: `fk_{table_name}_{column_name}`. For our example, the name would be `fk_books_author_id`.
+
+#### Example
+```php
+protected function migrate_to_10003(): bool
+{
+    // Drop the foreign key constraint using its auto-generated name.
+    $this->drop_foreign_key('fk_books_author_id');
+    
+    return true;
+}
+```
+
+---
+
+## Part 3: The "By Reference" Helper (Recommended)
+
+To avoid hardcoding table and column names (which can lead to typos), the library provides a cleaner and safer method that uses your `Table` objects directly.
+
+### `add_foreign_key_by_reference()`
+
+This is the **recommended way** to manage relationships between tables defined with this library. It reads the table name, foreign key name, and primary key name directly from the parent `Table` object.
+
+#### Signature
+`add_foreign_key_by_reference(Table_Interface $parent_table, string $on_delete = 'RESTRICT', string $on_update = 'RESTRICT', ?string $constraint_name = null): bool`
+
+#### Example
+Here is how you would use it inside a migration. Notice how much cleaner it is.
+```php
+// In Books_Table.php...
+protected function migrate_to_10004(): bool
+{
+    // You'll need an instance of the parent table.
+    $authors_table = new Authors_Table($this->wpdb);
+    
+    // Add the foreign key by simply passing the parent table object.
+    $this->add_foreign_key_by_reference(
+        $authors_table,
+        'CASCADE' // on_delete action
+    );
+        
+    return true;
+}
+```
+This method is less error-prone and automatically adapts if you ever change the parent table's name or primary key, making your code more maintainable.
+
+---
+
+### What's Next?
+
+You now have a complete understanding of how to build a relational database. The next guide will cover powerful shortcuts and helpers, including the `Meta_Table` class, which automates the creation of a very common type of one-to-many relationship.
+
+-   [**Next: Shortcuts and Helpers &rarr;**](./05-Shortcuts-and-Helpers.md)

--- a/docs/05-Shortcuts-and-Helpers.md
+++ b/docs/05-Shortcuts-and-Helpers.md
@@ -1,0 +1,168 @@
+# 5. Shortcuts and Helpers
+
+You now have the core skills to build and manage any table structure. This guide introduces the library's powerful shortcuts and helpers, designed to handle common database patterns for you, saving you time and reducing boilerplate code.
+
+---
+
+## Part 1: The `Meta_Table` Helper
+
+In WordPress, it's a very common pattern to have a main table (like `wp_posts`) and a corresponding metadata table (`wp_postmeta`) to store flexible key-value data. The abstract `Meta_Table` class automates this entire process for you.
+
+When you use `Meta_Table`, it handles everything:
+-   It defines the standard `meta_id`, `meta_key`, and `meta_value` columns.
+-   It automatically creates the foreign key column (e.g., `task_id`) based on the parent table you provide.
+-   It writes the entire initial migration and sets up the foreign key relationship for you.
+
+Your only job is to tell it which parent table it belongs to.
+
+### Step-by-Step Guide
+
+Let's create a `tasks_meta` table for our `Tasks_Table`.
+
+#### 1. Create the Meta Table Class
+Create a new file, `src/Database/Tables/Tasks_Meta_Table.php`. Instead of extending `Table`, you will **extend `Meta_Table`**.
+
+This class is incredibly minimal. You only need to define two properties:
+1.  `$table_singular_name`: The singular name of the **parent object**. For a `tasks` table, this would be `'task'`. The class uses this to name the table (`taskmeta`) and the foreign key (`task_id`).
+2.  `$plugin_prefix`: Your plugin's prefix.
+
+You do **not** need to create a constructor or a `migrate_to_10001()` method. The parent `Meta_Table` class does it all.
+
+**`src/Database/Tables/Tasks_Meta_Table.php`**
+```php
+<?php
+
+namespace Your_Plugin\Database\Tables;
+
+use WPTechnix\WP_Tables_Schema\Meta_Table;
+
+class Tasks_Meta_Table extends Meta_Table
+{
+    /**
+     * The singular name of the PARENT.
+     * This is the only required piece of configuration.
+     * @var string
+     */
+    protected string $table_singular_name = 'task';
+
+    /**
+     * The plugin's prefix.
+     * @var string
+     */
+    protected string $plugin_prefix = 'my_plugin_';
+}```
+
+#### 2. Update the Installer
+Next, go to your main installer function. The `Meta_Table` constructor requires the **parent table object** as its first argument.
+
+**`my-plugin.php`**
+```php
+<?php
+
+use Your_Plugin\Database\Tables\Tasks_Table;
+use Your_Plugin\Database\Tables\Tasks_Meta_Table;
+
+function my_plugin_install() {
+    global $wpdb;
+
+    // 1. Instantiate the parent table first.
+    $tasks_table = new Tasks_Table($wpdb);
+
+    // 2. Instantiate the meta table, passing the parent table object into it.
+    $tasks_meta_table = new Tasks_Meta_Table($tasks_table, $wpdb);
+
+    // 3. Run install() on both. It's best practice to install the parent first.
+    $tasks_table->install();
+    $tasks_meta_table->install();
+}
+
+register_activation_hook(__FILE__, 'my_plugin_install');
+```
+That's it! The library will automatically create the `wp_my_plugin_taskmeta` table with a perfect schema and a foreign key relationship to the `tasks` table.
+
+---
+
+## Part 2: Schema Builder Macros
+
+The schema builder includes several "macro" methods that are convenient shortcuts for common column patterns.
+
+### `->id()`
+You've already seen this one! It's a macro that creates a `BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY` column, which is the perfect primary key for most tables.
+`$schema->id();`
+
+### `->timestamps()`
+This macro adds two nullable `DATETIME` columns for tracking when a record is created and updated.
+-   `created_at`: Defaults to the current timestamp when a row is inserted.
+-   `updated_at`: Defaults to the current timestamp and automatically updates whenever the row is changed.
+
+`$schema->timestamps();`
+
+### `->soft_deletes()`
+This macro adds a single nullable `deleted_at` `DATETIME` column. This is used for "soft deleting"—marking a row as deleted by setting a timestamp, instead of actually removing it from the database.
+
+`$schema->soft_deletes();`
+
+### `->morphs()`
+This powerful macro is for creating **polymorphic relationships**. This is when a model (like an image or a comment) can belong to more than one other type of model.
+
+The `->morphs($name)` method creates two columns and a composite index on them:
+-   `{$name}_id` (BIGINT UNSIGNED): Stores the ID of the parent model.
+-   `{$name}_type` (VARCHAR): Stores a string identifying the parent's type (e.g., 'task' or 'project').
+
+**Example**: Let's create a `notes` table where notes can be attached to both `Tasks` and `Projects`.
+```php
+protected function migrate_to_10001(): bool
+{
+    return $this->create_table(function (Create_Table_Schema $schema) {
+        $schema->id();
+        $schema->text('content');
+        
+        // This creates 'notable_id' and 'notable_type' columns, plus an index.
+        $schema->morphs('notable');
+        
+        $schema->timestamps();
+        
+        return $schema;
+    });
+}
+```
+A note with `notable_id` = 15 and `notable_type` = 'task' belongs to Task #15. If `notable_type` were 'project', it would belong to Project #15.
+
+---
+
+## Part 3: Your Table Class as a Helper
+
+Your `Table` class isn't just for migrations; it's also a dynamic source of information about your table's structure. Using its getter methods in your code is far better than hardcoding table and column names.
+
+-   `get_table_name()`: Returns the full, prefixed table name.
+-   `get_primary_key()`: Returns the name of the primary key column.
+-   `get_foreign_key_name()`: Returns the conventional name for this table's foreign key when used in other tables.
+-   `get_table_alias()`: Returns the short alias for use in SQL JOINs.
+
+**Example**: Writing a clean, future-proof query to get a task by its ID.
+```php
+function get_task_by_id(int $task_id) {
+    global $wpdb;
+    
+    // Instantiate the table to get its properties.
+    $tasks_table = new Tasks_Table($wpdb);
+    
+    $table_name = $tasks_table->get_table_name();
+    $primary_key = $tasks_table->get_primary_key();
+    
+    // This query is now clean and resilient to future changes.
+    // If you ever rename the table or primary key, this code still works.
+    return $wpdb->get_row(
+        $wpdb->prepare(
+            "SELECT * FROM `{$table_name}` WHERE `{$primary_key}` = %d",
+            $task_id
+        )
+    );
+}
+```
+
+### What's Next?
+
+You are now familiar with the library's core features and powerful helpers. The final guide will cover specialized, advanced topics for handling unique requirements and debugging your migrations.
+
+-   [**Next: Advanced Topics &rarr;**](./06-Advanced-Topics.md)

--- a/docs/06-Advanced-Topics.md
+++ b/docs/06-Advanced-Topics.md
@@ -1,0 +1,155 @@
+# 6. Advanced Topics
+
+Congratulations on making it this far! You are now equipped with all the core skills for creating, managing, and relating database tables. This final guide covers specialized features for handling unique requirements like multisite networks, conditional logic, and robust error logging.
+
+---
+
+### 1. Fine-Tuning Table Creation Options
+
+While the library provides sensible defaults, you can fine-tune the table-level options directly within the schema builder.
+
+| Method | Description | Example SQL |
+| :--- | :--- | :--- |
+| `->engine($name)` | Sets the database storage engine. `InnoDB` is highly recommended for foreign key support. | `ENGINE=InnoDB` |
+| `->charset($name)` | Sets the default character set for the table. | `DEFAULT CHARACTER SET=utf8mb4` |
+| `->collation($name)`| Sets the default collation for character sorting and comparison. | `COLLATE=utf8mb4_unicode_ci` |
+| `->comment($text)` | Adds a descriptive comment to the table itself in the database schema. | `COMMENT='Stores all user-generated tasks.'` |
+| `->if_not_exists()`| Adds the `IF NOT EXISTS` clause to the `CREATE TABLE` statement. This prevents an error if the table already exists, though the library's versioning system already handles this safely. | `CREATE TABLE IF NOT EXISTS...` |
+
+**Example Usage:**
+```php
+protected function migrate_to_10001(): bool
+{
+    return $this->create_table(function (Create_Table_Schema $schema) {
+        // Apply table-level options at the top of the closure.
+        $schema->engine('InnoDB');
+        $schema->comment('Stores all user-generated tasks and their status.');
+
+        // Define columns as usual.
+        $schema->id();
+        $schema->string('title');
+        
+        return $schema;
+    });
+}
+```
+
+---
+
+### 2. Multisite Installations
+
+By default, every table you create is **site-specific**. In a multisite network, this means each site will get its own version of the table (e.g., `wp_2_tasks`, `wp_3_tasks`).
+
+However, sometimes you need a single table that is **shared across all sites** in the network. You can achieve this by setting one property in your `Table` class.
+
+-   `protected bool $multisite_shared = false;` (Default): Uses the site-specific prefix (`$wpdb->prefix`).
+-   `protected bool $multisite_shared = true;`: Uses the global network prefix (`$wpdb->base_prefix`).
+
+**Example**: Let's create a `global_logs` table that is shared across the entire network.
+```php
+<?php
+// In Global_Logs_Table.php
+
+class Global_Logs_Table extends Table
+{
+    // ... other properties
+    protected string $table_name = 'global_logs';
+    protected string $plugin_prefix = 'my_plugin_';
+    
+    /**
+     * By setting this to true, the table will be created using the base prefix
+     * (e.g., `wp_my_plugin_global_logs`) and will be accessible from all sites.
+     * @var bool
+     */
+    protected bool $multisite_shared = true;
+    
+    // ... migration methods
+}
+```
+
+---
+
+### 3. Conditional Migrations
+
+Your plugin may be installed on a wide variety of server environments. Sometimes, you might want to run a migration that uses a feature only available in a newer version of MySQL or MariaDB. The library includes helper methods to check the database version safely.
+
+-   `is_mysql_at_least('version_string')`
+-   `is_mariadb_at_least('version_string')`
+
+**Example**: Imagine a new, faster index type becomes available in MariaDB 10.6. You want to upgrade an index for users on that version, but not break sites on older versions.
+```php
+protected function migrate_to_10005(): bool
+{
+    // Check if the site is running a compatible MariaDB version.
+    if ($this->is_mariadb_at_least('10.6')) {
+    
+        // Only run this advanced logic for compatible sites.
+        $this->drop_index('idx_tasks_title');
+        
+        // This is a hypothetical example of a version-specific feature.
+        $this->wpdb->query(
+            "ALTER TABLE {$this->get_table_name()} ADD INDEX idx_tasks_title (title) COMMENT 'Using new algorithm'"
+        );
+    }
+    
+    // IMPORTANT: Always return true so the version number is updated for everyone,
+    // even if the conditional logic didn't run.
+    return true;
+}
+```
+
+---
+
+### 4. Logging for Effective Debugging
+
+Database migrations can sometimes fail, especially on live servers with unexpected configurations. Debugging these issues can be difficult. To solve this, the library supports the **PSR-3 Logger Interface**, a popular standard for logging in PHP.
+
+By providing a logger, you can automatically capture any errors that happen during the `install()` process to a log file, complete with detailed messages and stack traces.
+
+#### Step 1: Install a Logger
+First, add a PSR-3 compliant logger to your project. **Monolog** is the most popular and recommended choice.
+```bash
+composer require monolog/monolog
+```
+
+#### Step 2: Create and Inject the Logger
+In your main installation function, create an instance of your logger and pass it to your `Table` object using the `setLogger()` method.
+
+**`my-plugin.php`**
+```php
+<?php
+use Your_Plugin\Database\Tables\Tasks_Table;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+
+function my_plugin_install() {
+    global $wpdb;
+
+    // --- Logger Setup ---
+    // 1. Create a new logger instance. 'db-migrations' is the channel name.
+    $log = new Logger('db-migrations');
+    
+    // 2. Create a handler to write logs to a file in your plugin's directory.
+    //    We'll only log messages that are WARNING level or higher.
+    $log_file = __DIR__ . '/migrations.log';
+    $log->pushHandler(new StreamHandler($log_file, Level::Warning));
+    // ------------------
+    
+    // Instantiate your table.
+    $tasks_table = new Tasks_Table($wpdb);
+
+    // 3. Inject the logger into the table object.
+    $tasks_table->setLogger($log);
+    
+    // Now, run the installation.
+    $tasks_table->install(); 
+}
+
+register_activation_hook(__FILE__, 'my_plugin_install');
+```
+Now, if any `Tasks_Table` migration fails due to a SQL error or any other exception, a `migrations.log` file will appear in your plugin's root directory. It will contain a detailed error message, making it incredibly easy to diagnose and fix the problem.
+
+---
+
+You have now completed the full documentation for WP Tables Schema. You have the knowledge to build simple tables, evolve them with complex migrations, connect them with relationships, and manage advanced, real-world scenarios with confidence. Happy coding


### PR DESCRIPTION
## Description

Introduces a complete set of developer-focused documentation to improve project onboarding and usability. The project previously lacked formal guides, making it difficult for new users to understand the library's full capabilities.

This commit adds the following:
- A revamped `README.md` with a clear overview and quick-start guide.
- A new `/docs` directory containing a full, step-by-step learning path:
  - `01-Getting-Started.md`: Covers installation and core concepts.
  - `02-The-Schema-Builder.md`: Details column and index creation methods.
  - `03-Evolving-Tables-with-Migrations.md`: Explains how to alter tables.
  - `04-Managing-Table-Relationships.md`: A deep dive into foreign keys.
  - `05-Shortcuts-and-Helpers.md`: Covers the Meta_Table class and helpers.
  - `06-Advanced-Topics.md`: Details multisite, logging, and other topics.

This provides a clear and comprehensive resource for all developers, aiming to reduce the learning curve and showcase the library's features.